### PR TITLE
feat: display, dark mode, lock, sleep and screenshot handlers

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: "3.12"
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,7 +9,7 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   unit_tests:
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: macos-14

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PHAL-plugin-mac
 
-[![Status: Security Fixes Only](https://img.shields.io/badge/status-security%20fixes%20only-orange)](https://github.com/OscillateLabsLLC/.github/blob/main/SUPPORT_STATUS.md)
+[![Status: Active](https://img.shields.io/badge/status-active-brightgreen)](https://github.com/OscillateLabsLLC/.github/blob/main/SUPPORT_STATUS.md)
 
 Provides system specific commands to OVOS for Mac OS. Creates fake ducking for OCP/ovos-media, barge-in volume adjustment, GUI button compatability, and allows for management of OVOS services.
 
@@ -36,25 +36,58 @@ Be sure to replace `<username>` with the username of the user running the OVOS i
 
 ## Handle bus events to interact with the OS
 
-```python
-# System
-self.bus.on("system.ntp.sync", self.handle_ntp_sync_request)
-self.bus.on("system.ssh.status", self.handle_ssh_status)
-self.bus.on("system.ssh.enable", self.handle_ssh_enable_request)
-self.bus.on("system.ssh.disable", self.handle_ssh_disable_request)
-self.bus.on("system.reboot", self.handle_reboot_request)
-self.bus.on("system.shutdown", self.handle_shutdown_request)
-self.bus.on("system.configure.language", self.handle_configure_language_request)
-self.bus.on("system.mycroft.service.restart", self.handle_mycroft_restart_request)
-# Volume
-self.bus.on("mycroft.volume.get", self.handle_volume_get)
-self.bus.on("mycroft.volume.set", self.handle_volume_set)
-self.bus.on("mycroft.volume.decrease", self.handle_volume_decrease)
-self.bus.on("mycroft.volume.increase", self.handle_volume_increase)
-self.bus.on("mycroft.volume.mute", self.handle_volume_mute)
-self.bus.on("mycroft.volume.unmute", self.handle_volume_unmute)
-self.bus.on("mycroft.volume.mute.toggle", self.handle_volume_mute_toggle)
-```
+### System
+
+- `system.ntp.sync`
+- `system.ssh.status`, `system.ssh.enable`, `system.ssh.disable`
+- `system.reboot`, `system.shutdown`
+- `system.configure.language`
+- `system.mycroft.service.restart`
+
+### Volume
+
+- `mycroft.volume.get`, `mycroft.volume.set`
+- `mycroft.volume.increase`, `mycroft.volume.decrease`
+- `mycroft.volume.mute`, `mycroft.volume.unmute`, `mycroft.volume.mute.toggle`
+
+### Display brightness
+
+Uses the canonical OVOS PHAL brightness namespace:
+
+- `phal.brightness.control.get` → replies with `phal.brightness.control.get.response` `{"brightness": 0..100}`
+- `phal.brightness.control.set` → `{"brightness": 0..100}`, replies with `phal.brightness.control.set.confirm`
+- `phal.brightness.control.sync` → re-emits `phal.brightness.control.get.response`
+- `phal.brightness.control.auto.dim.update` → no-op on macOS (auto-dim is OS-managed via System Settings → Lock Screen)
+
+> **Optional dependency:** macOS has no built-in command-line API for display
+> brightness. To enable brightness handling, install the small Homebrew
+> formula `brightness`:
+>
+> ```sh
+> brew install brightness
+> ```
+>
+> If `brightness` is not on `PATH`, the plugin still loads and the brightness
+> handlers become no-ops (a warning is logged on startup). All other
+> functionality is unaffected.
+>
+> The screenshot location can be customised via the `screenshot_dir` config
+> key (default `~/Pictures`).
+
+### Display: dark mode (Mac-specific extension)
+
+These events are not yet part of the canonical OVOS message spec; they are
+provided here so Mac users can drive macOS appearance from skills:
+
+- `system.display.dark_mode.get` → replies with `system.display.dark_mode.get.response` `{"enabled": bool}`
+- `system.display.dark_mode.set` → `{"enabled": bool}`, replies with `.set.confirm` / `.set.failed`
+- `system.display.dark_mode.toggle` → flips current state, replies with `.set.confirm` / `.set.failed`
+
+### Power & screen (Mac-specific extension)
+
+- `system.lock` → locks the screen (`pmset displaysleepnow`); replies with `system.lock.confirm` / `system.lock.failed`
+- `system.sleep` → sleeps the Mac (`pmset sleepnow`); replies with `system.sleep.confirm` / `system.sleep.failed`
+- `system.screenshot` → captures the full screen via `screencapture -x`. Optional `{"path": str}`; defaults to `~/Pictures/ovos-screenshot-<timestamp>.png`. Replies with `system.screenshot.complete` `{"path": str}` / `system.screenshot.failed`
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ Uses the canonical OVOS PHAL brightness namespace:
 > functionality is unaffected.
 >
 > The screenshot location can be customised via the `screenshot_dir` config
-> key (default `~/Pictures`).
+> key. The default is the XDG cache location
+> (`$XDG_CACHE_HOME/ovos/screenshots`, falling back to
+> `~/.cache/ovos/screenshots`) so the plugin behaves correctly when running
+> as a background service.
 
 ### Display: dark mode (Mac-specific extension)
 

--- a/phal_plugin_mac/__init__.py
+++ b/phal_plugin_mac/__init__.py
@@ -1,6 +1,9 @@
 """macOS PHAL plugin for OVOS."""
 
+import os
+import shutil
 import subprocess
+from datetime import datetime
 
 import osascript
 from ovos_bus_client import Message
@@ -12,23 +15,55 @@ class MacOSPlugin(PHALPlugin):
 
     def __init__(self, bus=None, config=None, *args, **kwargs):
         super().__init__(bus=bus, config=config, name="ovos-PHAL-plugin-mac", *args, **kwargs)
-        # System events
-        self.bus.on("system.ntp.sync", self.handle_ntp_sync_request)
-        self.bus.on("system.ssh.status", self.handle_ssh_status)
-        self.bus.on("system.ssh.enable", self.handle_ssh_enable_request)
-        self.bus.on("system.ssh.disable", self.handle_ssh_disable_request)
-        self.bus.on("system.reboot", self.handle_reboot_request)
-        self.bus.on("system.shutdown", self.handle_shutdown_request)
-        self.bus.on("system.configure.language", self.handle_configure_language_request)
-        self.bus.on("system.mycroft.service.restart", self.handle_mycroft_restart_request)
-        # Volume events
-        self.bus.on("mycroft.volume.get", self.handle_volume_get)
-        self.bus.on("mycroft.volume.set", self.handle_volume_set)
-        self.bus.on("mycroft.volume.decrease", self.handle_volume_decrease)
-        self.bus.on("mycroft.volume.increase", self.handle_volume_increase)
-        self.bus.on("mycroft.volume.mute", self.handle_volume_mute)
-        self.bus.on("mycroft.volume.unmute", self.handle_volume_unmute)
-        self.bus.on("mycroft.volume.mute.toggle", self.handle_volume_mute_toggle)
+        for event, handler in self._handlers().items():
+            self.bus.on(event, handler)
+
+        if not self._brightness_binary_available():
+            self.log.warning(
+                "macOS has no built-in CLI for display brightness. "
+                "Install the optional 'brightness' Homebrew formula "
+                "(`brew install brightness`) to enable phal.brightness.control.* "
+                "handling on this device."
+            )
+
+    def _handlers(self):
+        """Return the {bus_event: handler_method} map this plugin owns.
+
+        Subclasses can override and merge with super()._handlers() to add or
+        replace events without re-stating the full list.
+        """
+        return {
+            # System
+            "system.ntp.sync": self.handle_ntp_sync_request,
+            "system.ssh.status": self.handle_ssh_status,
+            "system.ssh.enable": self.handle_ssh_enable_request,
+            "system.ssh.disable": self.handle_ssh_disable_request,
+            "system.reboot": self.handle_reboot_request,
+            "system.shutdown": self.handle_shutdown_request,
+            "system.configure.language": self.handle_configure_language_request,
+            "system.mycroft.service.restart": self.handle_mycroft_restart_request,
+            # Display: brightness (canonical PHAL events)
+            "phal.brightness.control.get": self.handle_brightness_get,
+            "phal.brightness.control.set": self.handle_brightness_set,
+            "phal.brightness.control.sync": self.handle_brightness_sync,
+            "phal.brightness.control.auto.dim.update": self.handle_brightness_auto_dim_update,
+            # Display: dark mode (Mac-specific extension)
+            "system.display.dark_mode.get": self.handle_dark_mode_get,
+            "system.display.dark_mode.set": self.handle_dark_mode_set,
+            "system.display.dark_mode.toggle": self.handle_dark_mode_toggle,
+            # Power & screen (Mac-specific extension)
+            "system.lock": self.handle_lock_request,
+            "system.sleep": self.handle_sleep_request,
+            "system.screenshot": self.handle_screenshot_request,
+            # Volume
+            "mycroft.volume.get": self.handle_volume_get,
+            "mycroft.volume.set": self.handle_volume_set,
+            "mycroft.volume.decrease": self.handle_volume_decrease,
+            "mycroft.volume.increase": self.handle_volume_increase,
+            "mycroft.volume.mute": self.handle_volume_mute,
+            "mycroft.volume.unmute": self.handle_volume_unmute,
+            "mycroft.volume.mute.toggle": self.handle_volume_mute_toggle,
+        }
 
     @property
     def allow_reboot(self):
@@ -44,6 +79,11 @@ class MacOSPlugin(PHALPlugin):
     def volume_change_interval(self):
         """Get the volume change interval percentage. Defaults to 10."""
         return self.config.get("volume_change_interval", 10)
+
+    @property
+    def screenshot_dir(self):
+        """Directory where screenshots are written. Defaults to ~/Pictures."""
+        return os.path.expanduser(self.config.get("screenshot_dir", "~/Pictures"))
 
     def _run_command(self, command, check=True):
         """Private method to run shell commands."""
@@ -87,6 +127,178 @@ class MacOSPlugin(PHALPlugin):
         if not mute:
             script = "set volume without output muted"
         self._run_applescript(script)
+
+    # ---- Display: brightness -------------------------------------------------
+
+    def _brightness_binary_available(self):
+        """True if the optional Homebrew `brightness` CLI is on PATH."""
+        return shutil.which("brightness") is not None
+
+    def _get_brightness(self):
+        """Read current display brightness as an int 0-100, or None on failure."""
+        if not self._brightness_binary_available():
+            return None
+        result = self._run_command(["brightness", "-l"])
+        if result is None or not result.stdout:
+            return None
+        # `brightness -l` prints lines like:
+        #   display 0: brightness 0.742188
+        # We take the first display we find.
+        for line in result.stdout.splitlines():
+            if "brightness" in line:
+                try:
+                    value = float(line.rsplit(" ", 1)[-1])
+                    return max(0, min(100, round(value * 100)))
+                except (ValueError, IndexError):
+                    continue
+        return None
+
+    def _set_brightness(self, level):
+        """Set the display brightness from a 0-100 percentage."""
+        if not self._brightness_binary_available():
+            return False
+        clamped = max(0, min(100, int(level)))
+        result = self._run_command(["brightness", f"{clamped / 100:.4f}"])
+        return result is not None
+
+    def handle_brightness_get(self, message: Message):
+        """Handle phal.brightness.control.get."""
+        level = self._get_brightness()
+        if level is None:
+            self.log.error("Could not read Mac display brightness")
+            return
+        self.bus.emit(message.reply(
+            "phal.brightness.control.get.response", {"brightness": level}
+        ))
+
+    def handle_brightness_set(self, message: Message):
+        """Handle phal.brightness.control.set."""
+        level = message.data.get("brightness")
+        if level is None:
+            self.log.error("phal.brightness.control.set missing 'brightness' field")
+            return
+        if self._set_brightness(level):
+            self.bus.emit(message.forward(
+                "phal.brightness.control.set.confirm",
+                {"brightness": max(0, min(100, int(level)))},
+            ))
+
+    def handle_brightness_sync(self, message: Message):
+        """Handle phal.brightness.control.sync by re-emitting current level."""
+        level = self._get_brightness()
+        if level is None:
+            return
+        self.bus.emit(message.reply(
+            "phal.brightness.control.get.response", {"brightness": level}
+        ))
+
+    def handle_brightness_auto_dim_update(self, message: Message):
+        """Handle phal.brightness.control.auto.dim.update.
+
+        macOS does not expose a programmatic OVOS-style auto-dim toggle from
+        userland; this handler exists so the canonical event has an owner on
+        Mac and so callers don't see an unhandled-event warning. The actual
+        auto-dim behaviour on a Mac is controlled by the user via System
+        Settings → Lock Screen.
+        """
+        auto_dim = message.data.get("auto_dim")
+        self.log.info(
+            "phal.brightness.control.auto.dim.update received (auto_dim=%s); "
+            "no-op on macOS — auto-dim is managed by the OS.",
+            auto_dim,
+        )
+
+    # ---- Display: dark mode --------------------------------------------------
+
+    def _get_dark_mode(self):
+        """Return True if macOS is currently in Dark mode."""
+        script = (
+            'tell application "System Events" to tell appearance preferences '
+            'to get dark mode'
+        )
+        result = self._run_applescript(script)
+        if result is None:
+            return None
+        return "true" in result.lower()
+
+    def _set_dark_mode(self, enabled):
+        """Set macOS appearance to Dark (True) or Light (False)."""
+        value = "true" if enabled else "false"
+        script = (
+            'tell application "System Events" to tell appearance preferences '
+            f'to set dark mode to {value}'
+        )
+        return self._run_applescript(script) is not None
+
+    def handle_dark_mode_get(self, message: Message):
+        """Handle system.display.dark_mode.get."""
+        enabled = self._get_dark_mode()
+        if enabled is None:
+            self.log.error("Could not read Mac dark mode state")
+            return
+        self.bus.emit(message.reply(
+            "system.display.dark_mode.get.response", {"enabled": enabled}
+        ))
+
+    def handle_dark_mode_set(self, message: Message):
+        """Handle system.display.dark_mode.set."""
+        enabled = bool(message.data.get("enabled", False))
+        if self._set_dark_mode(enabled):
+            self.bus.emit(message.forward(
+                "system.display.dark_mode.set.confirm", {"enabled": enabled}
+            ))
+        else:
+            self.bus.emit(message.forward("system.display.dark_mode.set.failed"))
+
+    def handle_dark_mode_toggle(self, message: Message):
+        """Handle system.display.dark_mode.toggle."""
+        current = self._get_dark_mode()
+        if current is None:
+            self.bus.emit(message.forward("system.display.dark_mode.set.failed"))
+            return
+        new_state = not current
+        if self._set_dark_mode(new_state):
+            self.bus.emit(message.forward(
+                "system.display.dark_mode.set.confirm", {"enabled": new_state}
+            ))
+        else:
+            self.bus.emit(message.forward("system.display.dark_mode.set.failed"))
+
+    # ---- Power & screen ------------------------------------------------------
+
+    def handle_lock_request(self, message: Message):
+        """Handle system.lock — lock the screen."""
+        # `pmset displaysleepnow` is the most reliable way to lock the
+        # screen on modern macOS without invoking GUI APIs.
+        try:
+            self._run_command(["pmset", "displaysleepnow"])
+            self.bus.emit(message.forward("system.lock.confirm"))
+        except subprocess.CalledProcessError:
+            self.bus.emit(message.forward("system.lock.failed"))
+
+    def handle_sleep_request(self, message: Message):
+        """Handle system.sleep — put the Mac to sleep."""
+        try:
+            self._run_command(["pmset", "sleepnow"])
+            self.bus.emit(message.forward("system.sleep.confirm"))
+        except subprocess.CalledProcessError:
+            self.bus.emit(message.forward("system.sleep.failed"))
+
+    def handle_screenshot_request(self, message: Message):
+        """Handle system.screenshot — capture the full screen to disk."""
+        path = message.data.get("path")
+        if not path:
+            os.makedirs(self.screenshot_dir, exist_ok=True)
+            stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+            path = os.path.join(self.screenshot_dir, f"ovos-screenshot-{stamp}.png")
+        try:
+            # -x suppresses the camera-shutter sound.
+            self._run_command(["screencapture", "-x", path])
+            self.bus.emit(message.forward("system.screenshot.complete", {"path": path}))
+        except subprocess.CalledProcessError:
+            self.bus.emit(message.forward("system.screenshot.failed"))
+
+    # ---- Volume --------------------------------------------------------------
 
     def handle_volume_get(self, message: Message):
         """Handle the volume get request."""

--- a/phal_plugin_mac/__init__.py
+++ b/phal_plugin_mac/__init__.py
@@ -82,8 +82,18 @@ class MacOSPlugin(PHALPlugin):
 
     @property
     def screenshot_dir(self):
-        """Directory where screenshots are written. Defaults to ~/Pictures."""
-        return os.path.expanduser(self.config.get("screenshot_dir", "~/Pictures"))
+        """Directory where screenshots are written.
+
+        Defaults to the XDG cache location (`$XDG_CACHE_HOME/ovos/screenshots`,
+        falling back to `~/.cache/ovos/screenshots`) to match other OVOS
+        components and to behave correctly when the plugin runs as a
+        background service rather than as the logged-in user.
+        """
+        configured = self.config.get("screenshot_dir")
+        if configured:
+            return os.path.expanduser(configured)
+        xdg_cache = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+        return os.path.join(xdg_cache, "ovos", "screenshots")
 
     def _run_command(self, command, check=True):
         """Private method to run shell commands."""
@@ -291,6 +301,7 @@ class MacOSPlugin(PHALPlugin):
             os.makedirs(self.screenshot_dir, exist_ok=True)
             stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
             path = os.path.join(self.screenshot_dir, f"ovos-screenshot-{stamp}.png")
+        self.log.info("Capturing screenshot to %s", path)
         try:
             # -x suppresses the camera-shutter sound.
             self._run_command(["screencapture", "-x", path])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 authors = [{ name = "Mike Gray", email = "mike@oscillatelabs.net" }]
 license = { text = "Apache-2.0" }
 keywords = ["ovos", "plugin", "voice", "assistant"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dynamic = ["version", "dependencies", "optional-dependencies", "description"]
 
 [project.urls]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,3 +3,8 @@ ovos-bus-client
 ovos-workshop
 ovos-plugin-manager
 osascript==2020.12.3
+# Transitive override: orjson 3.10.12 (pulled in by ovos-utils 0.6.0) ships
+# a malformed sdist pyproject.toml that newer uv refuses to parse, and there
+# are no cp314 wheels for it. 3.11.0+ has Python 3.14 wheels and a valid
+# pyproject. Drop once ovos-utils bumps its floor.
+orjson>=3.11.0

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -328,3 +328,159 @@ def test_handle_mycroft_restart_request(mock_run, plugin, message, bus):
     mock_run.assert_any_call(["launchctl", "stop", "com.ovos.service"], check=True, capture_output=True, text=True)
     mock_run.assert_any_call(["launchctl", "start", "com.ovos.service"], check=True, capture_output=True, text=True)
     assert len(received_messages) == 1
+
+
+# ---- Brightness ----------------------------------------------------------
+
+
+@patch("phal_plugin_mac.shutil.which", return_value="/opt/homebrew/bin/brightness")
+@patch("phal_plugin_mac.MacOSPlugin._run_command")
+def test_handle_brightness_get(mock_run_command, _mock_which, plugin, message, bus):
+    received_messages = []
+    bus.on("phal.brightness.control.get.response", lambda m: received_messages.append(m))
+
+    mock_run_command.return_value = MagicMock(stdout="display 0: brightness 0.742188\n")
+    plugin.handle_brightness_get(message)
+
+    assert len(received_messages) == 1
+    assert received_messages[0].data["brightness"] == 74
+
+
+@patch("phal_plugin_mac.shutil.which", return_value=None)
+def test_handle_brightness_get_no_binary(_mock_which, plugin, message, bus):
+    received_messages = []
+    bus.on("phal.brightness.control.get.response", lambda m: received_messages.append(m))
+
+    plugin.handle_brightness_get(message)
+
+    assert received_messages == []
+
+
+@patch("phal_plugin_mac.shutil.which", return_value="/opt/homebrew/bin/brightness")
+@patch("phal_plugin_mac.MacOSPlugin._run_command")
+def test_handle_brightness_set(mock_run_command, _mock_which, plugin, bus):
+    received_messages = []
+    bus.on("phal.brightness.control.set.confirm", lambda m: received_messages.append(m))
+
+    mock_run_command.return_value = MagicMock(stdout="")
+    msg = Message("phal.brightness.control.set", {"brightness": 60})
+    plugin.handle_brightness_set(msg)
+
+    mock_run_command.assert_called_once_with(["brightness", "0.6000"])
+    assert len(received_messages) == 1
+    assert received_messages[0].data["brightness"] == 60
+
+
+@patch("phal_plugin_mac.shutil.which", return_value="/opt/homebrew/bin/brightness")
+@patch("phal_plugin_mac.MacOSPlugin._run_command")
+def test_handle_brightness_set_clamps(mock_run_command, _mock_which, plugin, bus):
+    mock_run_command.return_value = MagicMock(stdout="")
+    msg = Message("phal.brightness.control.set", {"brightness": 250})
+    plugin.handle_brightness_set(msg)
+    mock_run_command.assert_called_once_with(["brightness", "1.0000"])
+
+
+def test_handle_brightness_auto_dim_update_is_noop(plugin, message):
+    # Should not raise; behaviour is purely informational on macOS.
+    message.data["auto_dim"] = True
+    plugin.handle_brightness_auto_dim_update(message)
+
+
+# ---- Dark mode -----------------------------------------------------------
+
+
+@patch("phal_plugin_mac.MacOSPlugin._run_applescript")
+def test_handle_dark_mode_get(mock_run_applescript, plugin, message, bus):
+    received_messages = []
+    bus.on("system.display.dark_mode.get.response", lambda m: received_messages.append(m))
+
+    mock_run_applescript.return_value = "true"
+    plugin.handle_dark_mode_get(message)
+
+    assert len(received_messages) == 1
+    assert received_messages[0].data["enabled"] is True
+
+
+@patch("phal_plugin_mac.MacOSPlugin._run_applescript")
+def test_handle_dark_mode_set(mock_run_applescript, plugin, bus):
+    received_messages = []
+    bus.on("system.display.dark_mode.set.confirm", lambda m: received_messages.append(m))
+
+    mock_run_applescript.return_value = ""
+    msg = Message("system.display.dark_mode.set", {"enabled": True})
+    plugin.handle_dark_mode_set(msg)
+
+    assert len(received_messages) == 1
+    assert received_messages[0].data["enabled"] is True
+    # Confirm the AppleScript carries the literal "true".
+    args, _ = mock_run_applescript.call_args
+    assert "set dark mode to true" in args[0]
+
+
+@patch("phal_plugin_mac.MacOSPlugin._run_applescript")
+def test_handle_dark_mode_toggle(mock_run_applescript, plugin, message, bus):
+    received_messages = []
+    bus.on("system.display.dark_mode.set.confirm", lambda m: received_messages.append(m))
+
+    # First call (get) returns "false", second call (set) returns "" (success).
+    mock_run_applescript.side_effect = ["false", ""]
+    plugin.handle_dark_mode_toggle(message)
+
+    assert len(received_messages) == 1
+    assert received_messages[0].data["enabled"] is True
+
+
+# ---- Lock / sleep / screenshot ------------------------------------------
+
+
+@patch("phal_plugin_mac.MacOSPlugin._run_command")
+def test_handle_lock_request(mock_run_command, plugin, message, bus):
+    received_messages = []
+    bus.on("system.lock.confirm", lambda m: received_messages.append(m))
+
+    plugin.handle_lock_request(message)
+
+    mock_run_command.assert_called_once_with(["pmset", "displaysleepnow"])
+    assert len(received_messages) == 1
+
+
+@patch("phal_plugin_mac.MacOSPlugin._run_command")
+def test_handle_sleep_request(mock_run_command, plugin, message, bus):
+    received_messages = []
+    bus.on("system.sleep.confirm", lambda m: received_messages.append(m))
+
+    plugin.handle_sleep_request(message)
+
+    mock_run_command.assert_called_once_with(["pmset", "sleepnow"])
+    assert len(received_messages) == 1
+
+
+@patch("phal_plugin_mac.MacOSPlugin._run_command")
+def test_handle_screenshot_request_default_path(mock_run_command, plugin, message, bus, tmp_path):
+    received_messages = []
+    bus.on("system.screenshot.complete", lambda m: received_messages.append(m))
+
+    plugin.config["screenshot_dir"] = str(tmp_path)
+    plugin.handle_screenshot_request(message)
+
+    assert len(received_messages) == 1
+    path = received_messages[0].data["path"]
+    assert path.startswith(str(tmp_path))
+    assert path.endswith(".png")
+    mock_run_command.assert_called_once()
+    args, _ = mock_run_command.call_args
+    assert args[0][:2] == ["screencapture", "-x"]
+    assert args[0][2] == path
+
+
+@patch("phal_plugin_mac.MacOSPlugin._run_command")
+def test_handle_screenshot_request_explicit_path(mock_run_command, plugin, bus, tmp_path):
+    received_messages = []
+    bus.on("system.screenshot.complete", lambda m: received_messages.append(m))
+
+    target = str(tmp_path / "shot.png")
+    msg = Message("system.screenshot", {"path": target})
+    plugin.handle_screenshot_request(msg)
+
+    mock_run_command.assert_called_once_with(["screencapture", "-x", target])
+    assert received_messages[0].data["path"] == target


### PR DESCRIPTION
## Summary

Adds Tier 1 system control to the macOS PHAL plugin and reactivates the support status now that OVOS ships official macOS support.

### Canonical OVOS bus events (from `ovos-pydantic-models`)

- `phal.brightness.control.get` → `phal.brightness.control.get.response` `{brightness: 0..100}`
- `phal.brightness.control.set` `{brightness: 0..100}` → `phal.brightness.control.set.confirm`
- `phal.brightness.control.sync` → re-emits `.get.response`
- `phal.brightness.control.auto.dim.update` → no-op on macOS (auto-dim is OS-managed via System Settings → Lock Screen). Logged so the canonical event has an owner on Mac.

### Mac-specific extensions (no canonical event yet)

These are Mac-only for now. If/when they land in `ovos-pydantic-models` we can renamespace.

- `system.display.dark_mode.get` / `.set` / `.toggle`
- `system.lock` (`pmset displaysleepnow`)
- `system.sleep` (`pmset sleepnow`)
- `system.screenshot` (configurable `screenshot_dir`, default `~/Pictures`)

### Brightness — optional Homebrew dep

macOS has no built-in CLI for display brightness. The plugin feature-detects the optional `brightness` Homebrew formula on startup; if it isn't on `PATH` the brightness handlers become no-ops and a single warning is logged. No hard install dependency added. Documented in the README.

### Refactor: data-driven handler registration

Replaces the long list of `self.bus.on(...)` calls in `__init__` with a single `_handlers()` dict literal returning `{event: bound_method}`. Subclasses can extend via `super()._handlers()`. Net -21 lines, no behavior change, all existing tests still pass.

### Status badge

Bumped from \"security fixes only\" to \"active\". OVOS now ships official macOS support, so this plugin is back on the feature track.

## Test plan

- [x] `uv run pytest -q` — 42/42 passing, 84% coverage
- [x] `uv run ruff check phal_plugin_mac test` — clean
- [ ] Manual smoke on a Mac: brightness get/set with `brightness` installed, dark mode toggle, lock, sleep, screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)