### PR TITLE
fix(deps): consolidate dependency declarations into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,24 @@ authors = [{ name = "Mike Gray", email = "mike@oscillatelabs.net" }]
 license = { text = "Apache-2.0" }
 keywords = ["ovos", "plugin", "voice", "assistant"]
 requires-python = ">=3.10"
-dynamic = ["version", "dependencies", "optional-dependencies", "description"]
+dynamic = ["version", "description"]
+dependencies = [
+    "ovos-utils",
+    "ovos-bus-client",
+    "ovos-workshop",
+    "ovos-plugin-manager",
+    # Transitive override: orjson 3.10.12 (pulled in by ovos-utils 0.6.0) ships
+    # a malformed sdist pyproject.toml that newer uv refuses to parse, and there
+    # are no cp314 wheels for it. 3.11.0+ has Python 3.14 wheels and a valid
+    # pyproject. Drop once ovos-utils bumps its floor.
+    "orjson>=3.11.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov",
+]
 
 [project.urls]
 Homepage = "https://github.com/OscillateLabsLLC/ovos-phal-plugin-mac"
@@ -21,10 +38,6 @@ packages = ["ovos_phal_plugin_mac"]
 include-package-data = true
 
 [tool.setuptools.dynamic]
-dependencies = { file = ["requirements/requirements.txt"] }
-optional-dependencies = { test = { file = [
-    "requirements/requirements-dev.txt",
-] } }
 description = { file = "README.md" }
 version = { attr = "phal_plugin_mac.version.__version__" }
 
@@ -37,7 +50,6 @@ ovos_phal_plugin_mac = [
     "vocab/*",
     "regex/*",
     "ui/*",
-    "requirements/*",
 ]
 
 [project.entry-points."ovos.plugin.phal"]

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,2 +1,0 @@
-pytest
-pytest-cov

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,9 +1,0 @@
-ovos-utils
-ovos-bus-client
-ovos-workshop
-ovos-plugin-manager
-# Transitive override: orjson 3.10.12 (pulled in by ovos-utils 0.6.0) ships
-# a malformed sdist pyproject.toml that newer uv refuses to parse, and there
-# are no cp314 wheels for it. 3.11.0+ has Python 3.14 wheels and a valid
-# pyproject. Drop once ovos-utils bumps its floor.
-orjson>=3.11.0


### PR DESCRIPTION
## Summary
Same cleanup applied to `tts-plugin-mozilla_remote` — `requirements/*.txt` and `pyproject.toml`'s dynamic fields were two sources of truth for the same dependency list, kept in sync by hand.

- Moves `dependencies`/`optional-dependencies.test` to static PEP 621 arrays directly in `pyproject.toml`, matching `skill-mac-application-launcher`, `skill-musicassistant`, `ovos-kid-friendly-dialog-transformer`, and now `tts-plugin-mozilla_remote`.
- Preserves the orjson transitive-override comment (malformed sdist / no cp314 wheels below 3.11.0).
- Deletes `requirements/` — no longer referenced anywhere.

Unlike `tts-plugin-mozilla_remote`, this repo's CI already used `uv sync` and `python -m build` for every install path, so nothing was silently drifting here — this is preventative, not a live-bug fix.

## Test plan
- [x] `uv lock` resolves identically (no lockfile diff), `orjson` still resolves to `3.11.9` (satisfies `>=3.11.0`)
- [x] `uv run pytest` — 45/45 pass
- [x] `python -m build --sdist` succeeds; verified `Requires-Dist` in the built `PKG-INFO` matches all 4 direct deps + orjson override + test extra

🤖 Generated with [Claude Code](https://claude.com/claude-code)